### PR TITLE
Add missing dependency wcwidth to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "merge": "^1.2.0",
     "minimist": "^1.2.0",
     "smartwrap": "^1.0.3",
-    "strip-ansi": "^3.0.0"
+    "strip-ansi": "^3.0.0",
+    "wcwidth": "^1.0.1"
   },
   "devDependencies": {
     "babel-preset-babili": "0.0.12",

--- a/test/mocha.conf.js
+++ b/test/mocha.conf.js
@@ -4,12 +4,13 @@ var assert = chai.assert;
 var should = chai.should();
 var fs = require('fs');
 var glob = require('glob');
+var grunt = require('grunt');
 
 //Get list of all test scripts
-var list = glob.sync('examples/*.js'); 
+var list = glob.sync('examples/*.js');
 
 list.forEach(function(element,index,array){
-	
+
 	//Matching test
 	describe(element,function(){
 		it('Should match ' + element + '-output.txt',function(deferred){
@@ -24,7 +25,7 @@ list.forEach(function(element,index,array){
 					grunt.log.error('Exec error: ' + error);
 				}
 				var subname = element.split('.')[0];
-				var expected1 = fs.readFileSync('./'+subname+'-output.txt',{encoding : 'utf-8'}); 
+				var expected1 = fs.readFileSync('./'+subname+'-output.txt',{encoding : 'utf-8'});
 				stdout.should.equal(expected1);
 				deferred();
 			});


### PR DESCRIPTION
Dependency `wcwidth` used in [src/format.js](https://github.com/tecfu/tty-table/blob/master/src/format.js#L4) was not included in package.json. This commit adds it.