### PR TITLE
fixed negative width

### DIFF
--- a/src/format.js
+++ b/src/format.js
@@ -254,10 +254,14 @@ Format.getColumnWidths = function(config,rows){
     let prop = process.stdout.columns / totalWidth;
   
     prop = prop.toFixed(2)-0.01;
+		
+		// when process.stdout.columns is 0, width will be negative
+		if (prop > 0) {
+			widths = widths.map(function(value){
+				return Math.floor(prop*value);
+			});
+		}
   
-    widths = widths.map(function(value){
-      return Math.floor(prop*value);
-    });
   }
 
   return widths;


### PR DESCRIPTION
I got this error in TravisCI osx System.

```
/Users/travis/build/Tencent/wepy/packages/wepy-cli/node_modules/tty-table/src/render.js:186
    let whiteline = Array(config.table.columnWidths[a]).join('\ ');
                    ^
RangeError: Invalid array length
    at /Users/travis/build/Tencent/wepy/packages/wepy-cli/node_modules/tty-table/src/render.js:186:21
    at Array.forEach (native)
    at Object.Render.buildRow (/Users/travis/build/Tencent/wepy/packages/wepy-cli/node_modules/tty-table/src/render.js:185:9)
```

and I found in TravisCI osx System, the `process.stdout.columns` is always `0`.

btw. in TravisCI ubuntu System, the `process.stdout.columns` is `80`