### PR TITLE
Mark `formatter` as optional

### DIFF
--- a/src/factory.d.ts
+++ b/src/factory.d.ts
@@ -18,7 +18,7 @@ declare namespace TtyTable {
     color?: string;
     footerAlign?: string;
     footerColor?: string;
-    formatter: Formatter;
+    formatter?: Formatter;
     headerAlign?: string;
     headerColor?: string;
     marginLeft?: number;


### PR DESCRIPTION
As far as I could verify this is actually optional.