### PR TITLE
fix: parse data after receiving complete standard input.

### DIFF
--- a/adapters/terminal-adapter.js
+++ b/adapters/terminal-adapter.js
@@ -111,15 +111,21 @@ const runTable = function (header, body) {
   previousHeight = t1.height
 }
 
+const chunks = []
 process.stdin.resume()
 process.stdin.setEncoding("utf8")
 process.stdin.on("data", function (chunk) {
+  chunks.push(chunk)
+})
+process.stdin.on("end", function () {
+  const stdin = chunks.join("")
+
   // handle dataFormats
   switch (true) {
     case (dataFormat === "json"):
       let data
       try {
-        data = JSON.parse(chunk)
+        data = JSON.parse(stdin)
       } catch (e) {
         emitError(
           "JSON parse error",
@@ -136,7 +142,7 @@ process.stdin.on("data", function (chunk) {
         }
       })
 
-      csv.parse(chunk, formatterOptions, function (err, data) {
+      csv.parse(stdin, formatterOptions, function (err, data) {
       // validate csv
         if (err || typeof data === "undefined") {
           emitError(


### PR DESCRIPTION
Thanks for the great software!

We have discovered a problem with receiving standard input via the CLI where chunks are split and data is corrupted unexpectedly.
This occurs frequently with data that routinely uses multi-bytes and tends to be large in size, such as Japanese.

After receiving standard input, we have changed to parse the data with `process.stdin.on("end")`.

Example of corrupted JSON:
![image](https://github.com/tecfu/tty-table/assets/34061817/57cd51f3-ffae-47f8-9655-4efcc156aa5b)
