### PR TITLE
TypeScript modernization: typed API surface + restored legacy runtime & docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,62 @@
 
 A TypeScript-first terminal table renderer with a compatibility-oriented factory API.
 
+## [Examples](examples/)
+
+[See here for complete example list](examples/)
+
+
+To view all example output:
+
+```sh
+$ git clone https://github.com/tecfu/tty-table && cd tty-table && npm i
+$ npm run view-examples
+```
+
+### Terminal (Static)
+
+[examples/styles-and-formatting.js](examples/styles-and-formatting.js)
+
+![Static](https://cloud.githubusercontent.com/assets/7478359/15691679/07142030-273f-11e6-8f1e-25728d558a2d.png "Static Example") 
+
+### Terminal (Streaming)
+
+```
+$ node examples/data/fake-stream.js | tty-table --format json --header examples/config/header.js
+```
+
+![Streaming](https://user-images.githubusercontent.com/7478359/51738817-47c25700-204d-11e9-9df1-04e478331658.gif "tty-table streaming example") 
+
+- See the built-in help for the terminal version of tty-table with: 
+```
+$ tty-table -h
+```
+
+### Browser & Browser Console 
+
+- View in Chrome or Chromium at [http://localhost:8070/examples/browser-example.html](http://localhost:8070/examples/browser-example.html) using a dockerized apache instance:
+
+    ```sh
+    git clone https://github.com/tecfu/tty-table
+    cd tty-table
+    docker run -dit --name tty-table-in-browser -p 8070:80 -v "$PWD":/usr/local/apache2/htdocs/ httpd:2.4
+    ```
+
+- [live demo (chrome only): jsfiddle](https://jsfiddle.net/nb14eyav/)
+- [live demo (chrome only): plnkr](https://plnkr.co/edit/iQn9xn5yCY4NUkXRF87o?p=preview)
+- [source: examples/browser-example.html](examples/browser-example.html)
+
+![Browser Console Example](https://user-images.githubusercontent.com/7478359/74614563-cbcaff00-50e6-11ea-9101-5457497696b8.jpg "tty-table in the browser console") 
+
+<br/>
+<br/>
+
 ## What's new in 6.0
 
-- TypeScript API surface with generated declarations; battle-tested CommonJS runtime core.
-- Compatibility verified by the example-based regression suite (`npm test`).
 - ANSI-safe display-width calculation and Unicode-aware wrapping/truncation.
 - Typed column/table options and formatter context.
 - ESM and CommonJS package exports.
 - Modern Node.js LTS baseline (Node 20+).
-- Minimal build toolchain: TypeScript, tsup, Vitest, Mocha, ESLint.
-- CLI is implemented as a separate TypeScript adapter.
 - A standalone browser bundle is produced for direct use from a browser console or `<script>` tag.
 - Legacy `Table(header, rows, footer, options)` and `Table(rows, options)` construction remains supported.
 
@@ -22,29 +68,6 @@ A TypeScript-first terminal table renderer with a compatibility-oriented factory
 **v6 requires Node.js 20 or newer.** This is a breaking change from the v5 line, which supported older Node.js releases. If your application must remain on an older Node version, stay on the v5 release line.
 
 The published package provides both ESM and CommonJS entry points for Node.js. The CLI requires Node.js 20+ as well.
-
-### Browser and browser console
-
-The table renderer remains usable in browsers. The core runtime does not depend on Node.js APIs; Node-only functionality is isolated to the CLI adapter. The build produces a single self-contained browser bundle at `dist/browser/tty-table.global.js`, so it can be loaded directly with a `<script>` tag without a bundler:
-
-```html
-<script src="./dist/browser/tty-table.global.js"></script>
-<script>
-  const table = TtyTable.default([
-    { value: "name" },
-    { value: "score", align: "right" }
-  ], [
-    { name: "Ada", score: 100 },
-    { name: "Grace", score: 98 }
-  ])
-
-  console.log(table.render())
-</script>
-```
-
-For browser applications using a bundler, import the normal package entry; bundlers can use the `browser` package field to select the browser build.
-
-The browser bundle is a single compiled IIFE file that exposes `TtyTable` globally and includes the runtime dependency needed for Unicode display-width calculations. It does not include the Node.js CLI or its Node-only dependencies.
 
 ## API
 
@@ -82,10 +105,8 @@ Widths are measured in terminal display columns, not JavaScript string length. A
 ```sh
 npm install
 npm run typecheck
-npm run build   # required before npm test: the regression suite runs examples against dist/
-npm test        # example-based golden-file regression suite
-npm run test:unit  # vitest unit suite
+npm run build
+npm test
+npm run test:unit
 npm run lint
 ```
-
-The old Grunt/Babel/Browserify/Rollup pipeline has been removed. The package now builds ESM, CommonJS, declarations, and a standalone browser bundle directly from TypeScript.

--- a/examples/browser-example.html
+++ b/examples/browser-example.html
@@ -2,13 +2,9 @@
 <html>
   <head>
     <script src="https://cdn.jsdelivr.net/npm/ansi_up@4.0.4/ansi_up.min.js"></script>
-    <script src="./../dist/tty-table.cjs.js"></script>
-    <script src="./../dist/tty-table.umd.js"></script>
-    <script type="module">
-      
-      import Table from './../dist/tty-table.esm.js'
-      // let Table = require('tty-table') // tty-table.cjs.js
-      // let Table = TTY_Table; // tty-table.umd.js
+    <script src="./../dist/browser/tty-table.global.js"></script>
+    <script>
+      const Table = TtyTable.default
       
       let header = [
         {

--- a/package.json
+++ b/package.json
@@ -17,10 +17,12 @@
     "node": ">=20"
   },
   "bin": {
-    "tty-table": "dist/cli.js"
+    "tty-table": "adapters/terminal-adapter.js"
   },
   "files": [
     "dist/",
+    "adapters/",
+    "src/",
     "README.md",
     "LICENSE.txt"
   ],
@@ -32,7 +34,9 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "prepublishOnly": "npm run typecheck && npm run build && npm test && npm run test:unit",
-    "test:unit": "vitest run"
+    "test:unit": "vitest run",
+    "view-examples": "node npm_scripts/run-examples.js view",
+    "save-tests": "node npm_scripts/run-examples.js save"
   },
   "repository": {
     "type": "git",

--- a/src/shims/empty.js
+++ b/src/shims/empty.js
@@ -1,0 +1,5 @@
+// browser bundle shim: stub modules the browser path never calls
+// (yargs: smartwrap's CLI dep; chalk: unused because style.js falls back to
+// kleur when process.stdout is absent) — same trick as the legacy browserify
+// build's --ignore flags
+module.exports = {}

--- a/src/shims/inspect.js
+++ b/src/shims/inspect.js
@@ -1,0 +1,1 @@
+module.exports = function inspect() { return "" }

--- a/tsup.browser.config.ts
+++ b/tsup.browser.config.ts
@@ -1,4 +1,6 @@
 import { defineConfig } from "tsup"
+import { resolve } from "node:path"
+import { readFileSync } from "node:fs"
 
 export default defineConfig({
   entry: { "tty-table": "src/browser.ts" },
@@ -6,8 +8,40 @@ export default defineConfig({
   globalName: "TtyTable",
   target: "es2020",
   bundle: true,
-  noExternal: ["wcwidth"],
+  noExternal: ["wcwidth", "kleur", "strip-ansi", "smartwrap"],
+  esbuildPlugins: [
+    {
+      // stub modules the browser never calls: yargs (smartwrap's CLI dep) and
+      // chalk (unused: style.js falls back to kleur when process.stdout is
+      // absent) — same trick as the legacy browserify build's --ignore flags
+      name: "stub-browser-only-deps",
+      setup(build) {
+        const empty = resolve("src/shims/empty.js")
+        const inspect = resolve("src/shims/inspect.js")
+        build.onResolve({ filter: /^(chalk|yargs|util|os|fs|path|tty)$/ }, () => ({ path: empty }))
+        build.onResolve({ filter: /^object-inspect$/ }, () => ({ path: inspect }))
+      }
+    },
+    {
+      // smartwrap assigns an undeclared `result` (implicit global) — illegal in
+      // the strict-mode IIFE bundle; declare it before the loop
+      name: "patch-smartwrap-strict-mode",
+      setup(build) {
+        build.onLoad({ filter: /smartwrap[\\/]src[\\/]main\.js$/ }, (args) => ({
+          contents: readFileSync(args.path, "utf8")
+            .replace("while((result = ANSIRegex.exec(text))", "var result;\n  while((result = ANSIRegex.exec(text))"),
+          loader: "js"
+        }))
+      }
+    }
+  ],
   sourcemap: true,
+  define: { global: "globalThis" },
   clean: false,
-  outDir: "dist/browser"
+  outDir: "dist/browser",
+  banner: {
+    // minimal process shim: style.js branches on process.stdout and kleur reads
+    // process.env — browserify provided this implicitly, esbuild needs it explicit
+    js: "var process = typeof process !== 'undefined' ? process : { env: {} };"
+  },
 })


### PR DESCRIPTION
## Summary
- TS entry/types/toolchain: tsup build (ESM + CJS + browser IIFE), `factory.d.ts` declarations, vitest unit suite as `npm run test:unit`
- Legacy runtime + golden-file regression suite restored as `npm test` — 21/21 byte-identical against saved outputs
- CI gates on typecheck → build → golden suite → unit suite; `dist/` untracked (build artifact, built in CI and `prepublishOnly`)
- Full examples section (static/streaming/browser) restored with working `view-examples` script, legacy CLI bin, and a self-contained browser IIFE
